### PR TITLE
Corrección

### DIFF
--- a/LiquidacionPortatil/frmRemisionManual.vb
+++ b/LiquidacionPortatil/frmRemisionManual.vb
@@ -1264,6 +1264,8 @@ Public Class frmRemisionManual
 			Me.pnlProducto.Controls.Add(Me.lbltckProducto)
 			lblListaExistencia.Clear()
 			txtListaCantidad.Clear()
+			_actualizaProductos = False
+
 		End If
 
 		If _dtProductos Is Nothing Then


### PR DESCRIPTION
Se corrige un problema al seleccionar una zona económica cuando previamente se seleccionó una sin que se cargaran datos.